### PR TITLE
fixing the url for git clone in the build readmes

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -29,7 +29,7 @@ Build Garlicoin Core
 
 1. Clone the garlicoin source code and cd into `garlicoin`
 
-        git clone https://github.com/garlicoin-project/garlicoin
+        git clone https://github.com/GarlicoinOrg/Garlicoin
         cd garlicoin
 
 2.  Build garlicoin-core:

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -276,7 +276,7 @@ Setup and Build Example: Arch Linux
 This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
 
     pacman -S git base-devel boost libevent python
-    git clone https://github.com/retosen/Garlicoin
+    git clone https://github.com/GarlicoinOrg/Garlicoin
     cd Garlicoin/
     ./autogen.sh
     ./configure --without-gui --with-incompatible-bdb --disable-tests


### PR DESCRIPTION
I wasn't sure if GarlicoinOrg or retosen was the correct repo to point to, so I assumed GarlicoinOrg. If it is somewhere else, let me know and I'll fix that.