### PR TITLE
Garlicoin: add dnsseed.rshaw.space to DNS seed list

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -219,7 +219,7 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
         // nodes with support for servicebits filtering should be at the top
-        vSeeds.emplace_back("dnsseed.brennanmcdonald.io", true);
+        vSeeds.emplace_back("dnsseed-testnet.brennanmcdonald.io", true);
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
@@ -301,7 +301,6 @@ public:
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
 
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
-	vSeeds.emplace_back("dnsseed.brennanmcdonald.io", true);
 
         fDefaultConsistencyChecks = true;
         fRequireStandard = false;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -129,6 +129,7 @@ public:
         // Note that of those with the service bits flag, most only support a subset of possible options
         //Put seed nodes here
         vSeeds.emplace_back("dnsseed.brennanmcdonald.io", true);
+        vSeeds.emplace_back("dnsseed.rshaw.space", true);
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,38);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);


### PR DESCRIPTION
I noticed the DNS seed node listed isn't working so I have created a DNS seed node located at https://github.com/ryan-shaw/garlicoin-seeder

There is a docker container that can be pulled from https://hub.docker.com/r/ryanshaw/garlicoin-seeder/tags/

This will be extremely useful to handle initial wallet syncs.