### PR TITLE
Change default mempool size to 300MB and add first checkpoint

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -147,6 +147,7 @@ public:
         checkpointData = (CCheckpointData) {
             {
                 {  0, uint256S("0x2ada80bf415a89358d697569c96eb98cdbf4c3b8878ac5722c01284492e27228")},
+                {  10000, uint256S("0xe3d63206131fbdc8e60be5625d3bf9168a8b0ebeb04332e39e9ff8f0c541eaf4")},
             }
         };
 

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -29,7 +29,7 @@ static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
 static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
-static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 5;
+static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
 static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 /** Default for -bytespersigop */


### PR DESCRIPTION
Now at 10k blocks I thought it would be a good idea to add a checkpoint [1].

This RP also includes settings the default mempool size to 300MB, with todays larger RAM servers 5MB is _very_ small, commit is cherry-picked from e91d752fb5a864db79109d91bd8511b733e2f2db

[1] https://en.bitcoin.it/wiki/Checkpoint_Lockin