### PR TITLE
Add DNS seed to test net

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -219,7 +219,8 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
         // nodes with support for servicebits filtering should be at the top
-        //vSeeds.emplace_back("dnsseed-testnet.brennanmcdonald.io", true);
+        vSeeds.emplace_back("dnsseed-testnet.brennanmcdonald.io", true);
+        vSeeds.emplace_back("dnsseed-testnet.rshaw.space", true);
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);


### PR DESCRIPTION
Now test net genesis is added DNS seeds would be good to add seeing as the network will be very small, the DNS seeder can track the nodes and provide nodes IPs to new nodes

(my seed entry isn't active yet)