### PR TITLE
fix compile with gcc 11 by adding missing '#include <deque>'

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -21,7 +21,7 @@
 #include <sys/stat.h>
 #include <signal.h>
 #include <future>
-
+#include <deque>
 #include <event2/thread.h>
 #include <event2/buffer.h>
 #include <event2/bufferevent.h>


### PR DESCRIPTION
httpserver.cpp:73:10: error: ‘deque’ in namespace ‘std’ does not name a template type
   73 |     std::deque<std::unique_ptr<WorkItem>> queue;
      |          ^~~~~
httpserver.cpp:32:1: note: ‘std::deque’ is defined in header ‘<deque>’; did you forget to ‘#include <deque>’?

Signed-off-by: Scott S <ssimmons9999@gmail.com>