### PR TITLE
Included array

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5,6 +5,7 @@
 
 #include <net_processing.h>
 
+#include <array>
 #include <addrman.h>
 #include <arith_uint256.h>
 #include <blockencodings.h>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -14,6 +14,7 @@
 #include <qt/platformstyle.h>
 #include <qt/sendcoinsentry.h>
 
+#include <array>
 #include <base58.h>
 #include <chainparams.h>
 #include <wallet/coincontrol.h>


### PR DESCRIPTION
Fixes compilation error: variable ‘std::array<std::pair<long unsigned int, CNode*>, 2> best’ has initializer but incomplete type