### PR TITLE
Included deque

### DIFF
--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <boost/test/unit_test.hpp>
 #include <cuckoocache.h>
+#include <deque>
 #include <script/sigcache.h>
 #include <test/test_bitcoin.h>
 #include <random.h>


### PR DESCRIPTION
Fixes compilation error: ‘deque’ is not a member of ‘std’